### PR TITLE
remove information about CLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
 WARNING! Please expect breaking changes and unstable APIs. Most of them are currently at an early, experimental stage.
 
-# Contributing
-
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.microsoft.com.
-
-When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
+# Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or


### PR DESCRIPTION
From a cursory glance at other Azure projects, they don't necessarily spell out that they need contributors to sign a CLA. That's part of the PR process.

closes #56.