### PR TITLE
fix absindex error when top is zero

### DIFF
--- a/lua/frame.go
+++ b/lua/frame.go
@@ -65,7 +65,7 @@ func (fr *Frame) extend(grow int) {
 // stack top).
 func (fr *Frame) absindex(index int) int {
 	// zero, positive, or pseudo index
-	if index > 0 || isPseudoIndex(index) {
+	if index >= 0 || isPseudoIndex(index) {
 		return index
 	}
 	// negative


### PR DESCRIPTION
Zero should be return when index is zero, instead of "fr.gettop() + index + 1".
